### PR TITLE
Enable TF32 matmuls and expose full BA diagnostics

### DIFF
--- a/extensions/colmap/src/bindings/bundle_adjustment.cc
+++ b/extensions/colmap/src/bindings/bundle_adjustment.cc
@@ -76,8 +76,25 @@ void BindBundleAdjustment(py::module_& m) {
       .def("validate", &BundleAdjustmentOptions::Validate);
 
   py::class_<BundleAdjustmentDiagnostics>(m, "BundleAdjustmentDiagnostics")
+      .def_readonly("num_reprojection_residuals",
+                    &BundleAdjustmentDiagnostics::num_reprojection_residuals)
+      .def_readonly("num_depth_residuals",
+                    &BundleAdjustmentDiagnostics::num_depth_residuals)
+      .def_readonly(
+          "num_intrinsics_prior_residuals",
+          &BundleAdjustmentDiagnostics::num_intrinsics_prior_residuals)
+      .def_readonly("num_scale_prior_residuals",
+                    &BundleAdjustmentDiagnostics::num_scale_prior_residuals)
       .def_readonly("num_residual_blocks",
                     &BundleAdjustmentDiagnostics::num_residual_blocks)
+      .def_readonly("num_parameter_blocks",
+                    &BundleAdjustmentDiagnostics::num_parameter_blocks)
+      .def_readonly("num_parameters",
+                    &BundleAdjustmentDiagnostics::num_parameters)
+      .def_readonly("num_iterations",
+                    &BundleAdjustmentDiagnostics::num_iterations)
+      .def_readonly("termination_type",
+                    &BundleAdjustmentDiagnostics::termination_type)
       .def_readonly("initial_cost", &BundleAdjustmentDiagnostics::initial_cost)
       .def_readonly("final_cost", &BundleAdjustmentDiagnostics::final_cost);
 

--- a/vidmap/run.py
+++ b/vidmap/run.py
@@ -73,6 +73,14 @@ def main(argv=None):
 
     load_mapping_runtime()
 
+    # Import torch only after the native mapping runtime: libtorch_cpu.so exports its own
+    # statically linked BLAS/LAPACK (dgemm_, dpotrf_, ...), and if it is loaded first those
+    # symbols win global resolution for SuiteSparse/Ceres, which makes CHOLMOD report
+    # "matrix not positive definite" and bundle adjustment fail.
+    import torch
+
+    torch.set_float32_matmul_precision("high")
+
     from vidmap.frontend.runner import run_local_frontend
 
     frontend = run_local_frontend(


### PR DESCRIPTION
Set `torch.set_float32_matmul_precision("high")` in the end-to-end entrypoint. The import has to come after `load_mapping_runtime()`: `libtorch_cpu.so` exports its own statically linked BLAS/LAPACK, and when torch is loaded first those symbols win global resolution for SuiteSparse/Ceres, so CHOLMOD reports "matrix not positive definite" and bundle adjustment fails.

Bind the rest of `BundleAdjustmentDiagnostics`. Every field is populated in `PopulateResult`, but only three were exposed, so the BA failure path in `adjuster.py` raised `AttributeError` on `termination_type` instead of logging the warning and restoring the last valid reconstruction.