### PR TITLE
Cut the single-core time out of mapping, and make the Ceres backend configurable

### DIFF
--- a/extensions/colmap/CMakeLists.txt
+++ b/extensions/colmap/CMakeLists.txt
@@ -12,6 +12,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+# Ceres may live outside the loader's search path, so keep the directories it was
+# linked from in the installed module's RPATH.
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 3.0.2 CONFIG REQUIRED)
@@ -43,6 +46,7 @@ set(
     src/types.cc
     src/solver_playback.cc
     src/ceres_loss.cc
+    src/solver_backend.cc
     src/conversion.cc
     src/mapping_problem.cc
     src/stages/image_pair_inliers.cc
@@ -65,6 +69,14 @@ target_include_directories(
     ${VIDMAP_COLMAP_INCLUDE_DIRS}
 )
 target_link_libraries(vidmap_native_algorithms PUBLIC ${VIDMAP_COLMAP_ESTIMATORS_TARGET})
+
+# COLMAP's static libraries can reference Abseil's logging internals without listing
+# Abseil in their exported configuration, which leaves the module with undefined
+# absl::log_internal symbols at import time.
+find_package(absl CONFIG QUIET)
+if(absl_FOUND)
+  target_link_libraries(vidmap_native_algorithms PUBLIC absl::log absl::check)
+endif()
 
 set(
   VIDMAP_NATIVE_BINDING_SOURCES

--- a/extensions/colmap/src/bindings/bundle_adjustment.cc
+++ b/extensions/colmap/src/bindings/bundle_adjustment.cc
@@ -72,6 +72,8 @@ void BindBundleAdjustment(py::module_& m) {
                      &BundleAdjustmentOptions::gradient_tolerance)
       .def_readwrite("parameter_tolerance",
                      &BundleAdjustmentOptions::parameter_tolerance)
+      .def_readwrite("solver_backend",
+                     &BundleAdjustmentOptions::solver_backend)
       .def_readwrite("playback", &BundleAdjustmentOptions::playback)
       .def("validate", &BundleAdjustmentOptions::Validate);
 

--- a/extensions/colmap/src/bindings/bundle_adjustment.cc
+++ b/extensions/colmap/src/bindings/bundle_adjustment.cc
@@ -76,8 +76,25 @@ void BindBundleAdjustment(py::module_& m) {
       .def("validate", &BundleAdjustmentOptions::Validate);
 
   py::class_<BundleAdjustmentDiagnostics>(m, "BundleAdjustmentDiagnostics")
+      .def_readonly("num_reprojection_residuals",
+                    &BundleAdjustmentDiagnostics::num_reprojection_residuals)
+      .def_readonly("num_depth_residuals",
+                    &BundleAdjustmentDiagnostics::num_depth_residuals)
+      .def_readonly(
+          "num_intrinsics_prior_residuals",
+          &BundleAdjustmentDiagnostics::num_intrinsics_prior_residuals)
+      .def_readonly("num_scale_prior_residuals",
+                    &BundleAdjustmentDiagnostics::num_scale_prior_residuals)
       .def_readonly("num_residual_blocks",
                     &BundleAdjustmentDiagnostics::num_residual_blocks)
+      .def_readonly("num_parameter_blocks",
+                    &BundleAdjustmentDiagnostics::num_parameter_blocks)
+      .def_readonly("num_parameters",
+                    &BundleAdjustmentDiagnostics::num_parameters)
+      .def_readonly("num_iterations",
+                    &BundleAdjustmentDiagnostics::num_iterations)
+      .def_readonly("termination_type",
+                    &BundleAdjustmentDiagnostics::termination_type)
       .def_readonly("initial_cost", &BundleAdjustmentDiagnostics::initial_cost)
       .def_readonly("final_cost", &BundleAdjustmentDiagnostics::final_cost);
 

--- a/extensions/colmap/src/bindings/global_positioning.cc
+++ b/extensions/colmap/src/bindings/global_positioning.cc
@@ -22,6 +22,23 @@ void BindGlobalPositioning(py::module_& m) {
       .def_readwrite("weight", &LossConfig::weight)
       .def("validate", &LossConfig::Validate);
 
+  py::enum_<LinearSolverType>(m, "LinearSolverType")
+      .value("SPARSE_SCHUR", LinearSolverType::kSparseSchur)
+      .value("ITERATIVE_SCHUR", LinearSolverType::kIterativeSchur);
+
+  py::enum_<PreconditionerType>(m, "PreconditionerType")
+      .value("JACOBI", PreconditionerType::kJacobi)
+      .value("SCHUR_JACOBI", PreconditionerType::kSchurJacobi)
+      .value("CLUSTER_JACOBI", PreconditionerType::kClusterJacobi)
+      .value("CLUSTER_TRIDIAGONAL", PreconditionerType::kClusterTridiagonal);
+
+  py::class_<SolverBackendOptions>(m, "SolverBackendOptions")
+      .def(py::init<>())
+      .def_readwrite("linear_solver", &SolverBackendOptions::linear_solver)
+      .def_readwrite("preconditioner", &SolverBackendOptions::preconditioner)
+      .def_readwrite("use_cuda", &SolverBackendOptions::use_cuda)
+      .def("validate", &SolverBackendOptions::Validate);
+
   py::enum_<MetricDepthResidualType>(m, "MetricDepthResidualType")
       .value("LINEAR", MetricDepthResidualType::kLinear)
       .value("LOG", MetricDepthResidualType::kLog)
@@ -135,6 +152,8 @@ void BindGlobalPositioning(py::module_& m) {
                      &GlobalPositionerOptions::gradient_tolerance)
       .def_readwrite("parameter_tolerance",
                      &GlobalPositionerOptions::parameter_tolerance)
+      .def_readwrite("solver_backend",
+                     &GlobalPositionerOptions::solver_backend)
       .def_readwrite("playback", &GlobalPositionerOptions::playback)
       .def("validate", &GlobalPositionerOptions::Validate);
 

--- a/extensions/colmap/src/solver_backend.cc
+++ b/extensions/colmap/src/solver_backend.cc
@@ -1,0 +1,66 @@
+#include "vidmap_native/solver_backend.h"
+
+#include <stdexcept>
+
+#include <ceres/version.h>
+
+// Sparse CUDA factorization only exists from Ceres 2.2 on; 2.1 offers the dense
+// CUDA backend alone.
+#define VIDMAP_CERES_HAS_CUDA_SPARSE \
+  (CERES_VERSION_MAJOR > 2 || (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 2))
+
+namespace vidmap {
+
+void SolverBackendOptions::Validate() const {
+  if (!use_cuda) return;
+  if (!ceres::IsDenseLinearAlgebraLibraryTypeAvailable(ceres::CUDA)) {
+    throw std::invalid_argument("Ceres was built without CUDA support");
+  }
+#if VIDMAP_CERES_HAS_CUDA_SPARSE
+  if (linear_solver == LinearSolverType::kSparseSchur &&
+      !ceres::IsSparseLinearAlgebraLibraryTypeAvailable(ceres::CUDA_SPARSE)) {
+    throw std::invalid_argument(
+        "Ceres was built without the CUDA sparse linear solver");
+  }
+#else
+  if (linear_solver == LinearSolverType::kSparseSchur) {
+    throw std::invalid_argument(
+        "sparse_schur has no CUDA backend before Ceres 2.2; use iterative_schur "
+        "or build against a newer Ceres");
+  }
+#endif
+}
+
+void SolverBackendOptions::Apply(ceres::Solver::Options* solver_options) const {
+  Validate();
+  switch (linear_solver) {
+    case LinearSolverType::kSparseSchur:
+      solver_options->linear_solver_type = ceres::SPARSE_SCHUR;
+      break;
+    case LinearSolverType::kIterativeSchur:
+      solver_options->linear_solver_type = ceres::ITERATIVE_SCHUR;
+      break;
+  }
+  switch (preconditioner) {
+    case PreconditionerType::kJacobi:
+      solver_options->preconditioner_type = ceres::JACOBI;
+      break;
+    case PreconditionerType::kSchurJacobi:
+      solver_options->preconditioner_type = ceres::SCHUR_JACOBI;
+      break;
+    case PreconditionerType::kClusterJacobi:
+      solver_options->preconditioner_type = ceres::CLUSTER_JACOBI;
+      break;
+    case PreconditionerType::kClusterTridiagonal:
+      solver_options->preconditioner_type = ceres::CLUSTER_TRIDIAGONAL;
+      break;
+  }
+  if (use_cuda) {
+    solver_options->dense_linear_algebra_library_type = ceres::CUDA;
+#if VIDMAP_CERES_HAS_CUDA_SPARSE
+    solver_options->sparse_linear_algebra_library_type = ceres::CUDA_SPARSE;
+#endif
+  }
+}
+
+}  // namespace vidmap

--- a/extensions/colmap/src/stages/bundle_adjustment.cc
+++ b/extensions/colmap/src/stages/bundle_adjustment.cc
@@ -102,7 +102,7 @@ class DefaultBundleAdjuster {
     AddDepthConstraints();
 
     ceres::Solver::Options solver_options;
-    solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
+    options_.solver_backend.Apply(&solver_options);
     solver_options.minimizer_progress_to_stdout = false;
     solver_options.num_threads =
         colmap::GetEffectiveNumThreads(options_.num_threads);
@@ -643,6 +643,7 @@ void IntrinsicsPriorRecord::Validate() const {
 void BundleAdjustmentOptions::Validate() const {
   playback.Validate();
   reprojection_loss.Validate();
+  solver_backend.Validate();
   if (min_track_length < 0 || num_threads == 0 || max_num_iterations <= 0 ||
       !std::isfinite(function_tolerance) || function_tolerance < 0.0 ||
       !std::isfinite(gradient_tolerance) || gradient_tolerance < 0.0 ||

--- a/extensions/colmap/src/stages/global_positioning.cc
+++ b/extensions/colmap/src/stages/global_positioning.cc
@@ -896,8 +896,7 @@ class GlobalPositioner {
         }
       }
     }
-    solver_options_.linear_solver_type = ceres::SPARSE_SCHUR;
-    solver_options_.preconditioner_type = ceres::CLUSTER_TRIDIAGONAL;
+    options_.solver_backend.Apply(&solver_options_);
     solver_options_.num_threads =
         colmap::GetEffectiveNumThreads(solver_options_.num_threads);
   }
@@ -1039,6 +1038,7 @@ class GlobalPositioner {
 
 void GlobalPositionerOptions::Validate() const {
   playback.Validate();
+  solver_backend.Validate();
   if (min_num_view_per_track <= 0 || random_seed < -1 ||
       !std::isfinite(random_init_scale) || random_init_scale < 0.0 ||
       !std::isfinite(uncalibrated_loss_downweight) ||

--- a/extensions/colmap/src/stages/video_rotation_averaging.cc
+++ b/extensions/colmap/src/stages/video_rotation_averaging.cc
@@ -20,6 +20,7 @@
 #include <limits>
 #include <queue>
 #include <stdexcept>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -310,7 +311,7 @@ void VideoRotationAveragingOptions::Validate() const {
       !std::isfinite(video_tracking_huber_scale) ||
       video_tracking_huber_scale <= 0.0 ||
       !std::isfinite(video_lc_cauchy_scale) || video_lc_cauchy_scale <= 0.0 ||
-      num_threads <= 0 || max_num_iterations <= 0) {
+      num_threads == 0 || num_threads < -1 || max_num_iterations <= 0) {
     throw std::invalid_argument("invalid rotation averaging options");
   }
 }
@@ -394,7 +395,10 @@ RotationAveragingResult RunVideoRotationAveraging(
   ceres::Solver::Options solver_options;
   solver_options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
   solver_options.max_num_iterations = options.max_num_iterations;
-  solver_options.num_threads = options.num_threads;
+  solver_options.num_threads =
+      options.num_threads > 0
+          ? options.num_threads
+          : static_cast<int>(std::max(1u, std::thread::hardware_concurrency()));
   ceres::Solver::Summary summary;
   ceres::Solve(solver_options, &ceres_problem, &summary);
   if (!summary.IsSolutionUsable()) return result;

--- a/extensions/colmap/src/vidmap_native/bundle_adjustment.h
+++ b/extensions/colmap/src/vidmap_native/bundle_adjustment.h
@@ -5,6 +5,7 @@
 
 #include "vidmap_native/ceres_loss.h"
 #include "vidmap_native/mapping_problem.h"
+#include "vidmap_native/solver_backend.h"
 #include "vidmap_native/solver_playback.h"
 
 namespace vidmap {
@@ -58,6 +59,7 @@ struct BundleAdjustmentOptions {
   double function_tolerance = 1e-6;
   double gradient_tolerance = 1e-10;
   double parameter_tolerance = 1e-8;
+  SolverBackendOptions solver_backend;
   SolverPlaybackOptions playback;
 
   void Validate() const;

--- a/extensions/colmap/src/vidmap_native/global_positioning.h
+++ b/extensions/colmap/src/vidmap_native/global_positioning.h
@@ -7,6 +7,7 @@
 
 #include "vidmap_native/ceres_loss.h"
 #include "vidmap_native/mapping_problem.h"
+#include "vidmap_native/solver_backend.h"
 #include "vidmap_native/solver_playback.h"
 
 namespace vidmap {
@@ -94,6 +95,7 @@ struct GlobalPositionerOptions {
   double function_tolerance = 1e-5;
   double gradient_tolerance = 1e-10;
   double parameter_tolerance = 1e-8;
+  SolverBackendOptions solver_backend;
   SolverPlaybackOptions playback;
 
   void Validate() const;

--- a/extensions/colmap/src/vidmap_native/solver_backend.h
+++ b/extensions/colmap/src/vidmap_native/solver_backend.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ceres/solver.h>
+
+namespace vidmap {
+
+enum class LinearSolverType {
+  kSparseSchur,
+  kIterativeSchur,
+};
+
+enum class PreconditionerType {
+  kJacobi,
+  kSchurJacobi,
+  kClusterJacobi,
+  kClusterTridiagonal,
+};
+
+// Which linear solver the large Schur-complement solves use. The sparse direct
+// default factorizes on one thread, so the iterative solver is the option that
+// scales with cores; CUDA moves the linear algebra onto the GPU and requires a
+// Ceres built with CUDA support.
+struct SolverBackendOptions {
+  LinearSolverType linear_solver = LinearSolverType::kSparseSchur;
+  PreconditionerType preconditioner = PreconditionerType::kSchurJacobi;
+  bool use_cuda = false;
+
+  void Validate() const;
+  void Apply(ceres::Solver::Options* solver_options) const;
+};
+
+}  // namespace vidmap

--- a/extensions/colmap/src/vidmap_native/video_rotation_averaging.h
+++ b/extensions/colmap/src/vidmap_native/video_rotation_averaging.h
@@ -15,6 +15,8 @@ struct VideoRotationAveragingOptions {
   double max_rotation_error_deg = 0.0;
   double video_tracking_huber_scale = 0.1;
   double video_lc_cauchy_scale = 0.05;
+  // One thread keeps rotation averaging byte-identical across runs; -1, or any
+  // count above one, trades that determinism for Ceres parallelism.
   int num_threads = 1;
   int max_num_iterations = 100;
 

--- a/vidmap/frontend/loop_closure/retrieval.py
+++ b/vidmap/frontend/loop_closure/retrieval.py
@@ -139,11 +139,12 @@ def compute_retrieval_features(
 
 def _load_descriptors(names, hfile):
     """Load one ordered descriptor set."""
-    return torch.from_numpy(np.stack([hfile[name]["global_descriptor"].__array__() for name in names])).float()
+    descriptors = np.stack([hfile[name]["global_descriptor"][()] for name in names])
+    return torch.as_tensor(descriptors, dtype=torch.float)
 
 
 def _pairs_from_score_matrix(scores, invalid, num_select, min_score, return_scores):
-    invalid = torch.from_numpy(invalid).to(scores.device)
+    invalid = torch.as_tensor(invalid, device=scores.device)
     invalid |= scores < min_score
     scores.masked_fill_(invalid, float("-inf"))
     count = min(num_select, scores.shape[1])

--- a/vidmap/map.py
+++ b/vidmap/map.py
@@ -46,7 +46,7 @@ def build_parser() -> ArgumentParser:
 
 
 def _run_local(mapping_conf, frontend_conf, args, run_options) -> int:
-    from vidmap.reconstruction import propagate_local_input_provenance, run_mapping
+    from vidmap.reconstruction import extract_point_colors, propagate_local_input_provenance, run_mapping
 
     output_dir = Path(args.output).expanduser()
     reconstruction = run_mapping(
@@ -58,6 +58,7 @@ def _run_local(mapping_conf, frontend_conf, args, run_options) -> int:
         overwrite_outputs=args.overwrite,
         output_dir=output_dir,
     )
+    extract_point_colors(reconstruction, args.mapper_inputs)
     reconstruction_dir = output_dir / "rec"
     reconstruction_dir.mkdir(parents=True, exist_ok=True)
     reconstruction.write(reconstruction_dir)

--- a/vidmap/mapper/native/solver_backend.py
+++ b/vidmap/mapper/native/solver_backend.py
@@ -1,0 +1,21 @@
+"""Shared translation of solver-backend configuration into native Ceres selections."""
+
+from vidmap.mapper.native.extension import native
+from vidmap.mapper.options.solver import SolverBackendOptions
+
+
+def apply_solver_backend(native_options, options: SolverBackendOptions) -> None:
+    """Point one native stage's solver at the configured Ceres linear solver."""
+    backend = native_options.solver_backend
+    backend.linear_solver = {
+        "sparse_schur": native.LinearSolverType.SPARSE_SCHUR,
+        "iterative_schur": native.LinearSolverType.ITERATIVE_SCHUR,
+    }[options.linear_solver]
+    backend.preconditioner = {
+        "jacobi": native.PreconditionerType.JACOBI,
+        "schur_jacobi": native.PreconditionerType.SCHUR_JACOBI,
+        "cluster_jacobi": native.PreconditionerType.CLUSTER_JACOBI,
+        "cluster_tridiagonal": native.PreconditionerType.CLUSTER_TRIDIAGONAL,
+    }[options.preconditioner]
+    backend.use_cuda = options.use_cuda
+    native_options.solver_backend = backend

--- a/vidmap/mapper/native/state.py
+++ b/vidmap/mapper/native/state.py
@@ -158,9 +158,11 @@ class SolveState:
             record.xyz = np.asarray(point.xyz, dtype=np.float64)
             record.color = np.asarray(point.color, dtype=np.uint8)
             record.error = float(point.error)
-            record.observations = np.asarray(
-                [(element.image_id, element.point2D_idx) for element in point.track.elements],
+            elements = point.track.elements
+            record.observations = np.fromiter(
+                (value for element in elements for value in (element.image_id, element.point2D_idx)),
                 dtype=np.uint32,
+                count=2 * len(elements),
             ).reshape((-1, 2))
             point3D_id = int(point3D_id)
             if point3D_id in loop_closure_sidecars:

--- a/vidmap/mapper/options/positioning.py
+++ b/vidmap/mapper/options/positioning.py
@@ -7,6 +7,7 @@ from pydantic import ConfigDict, Field, model_validator
 
 from vidmap.configuration.validators import dataclass as pydantic_dataclass
 from vidmap.configuration.validators import instantiate_nested_options
+from vidmap.mapper.options.solver import SolverBackendOptions
 
 ScaleLossName = Literal["trivial", "huber", "cauchy", "soft_l1"]
 NativeLossName = Literal["trivial", "soft_l1", "cauchy", "huber"]
@@ -144,6 +145,7 @@ class GPTemporalAccelerationOptions:
 @pydantic_dataclass(frozen=True, kw_only=True, config=ConfigDict(extra="forbid", strict=True))
 class GPOptions:
     common: GPCommonOptions = dc_field(default_factory=GPCommonOptions)
+    solver_backend: SolverBackendOptions = dc_field(default_factory=SolverBackendOptions)
     first_pass: GPFirstPassOptions = dc_field(default_factory=GPFirstPassOptions)
     second_pass: GPSecondPassOptions = dc_field(default_factory=GPSecondPassOptions)
     track_filter: GPTrackFilterOptions = dc_field(default_factory=GPTrackFilterOptions)
@@ -156,6 +158,7 @@ class GPOptions:
             raw,
             {
                 "common": GPCommonOptions,
+                "solver_backend": SolverBackendOptions,
                 "first_pass": GPFirstPassOptions,
                 "second_pass": GPSecondPassOptions,
                 "track_filter": GPTrackFilterOptions,

--- a/vidmap/mapper/options/refinement.py
+++ b/vidmap/mapper/options/refinement.py
@@ -7,6 +7,7 @@ from pydantic import ConfigDict, Field, model_validator
 
 from vidmap.configuration.validators import dataclass as pydantic_dataclass
 from vidmap.configuration.validators import instantiate_nested_options
+from vidmap.mapper.options.solver import SolverBackendOptions
 
 ReprojectionLossName = Literal["trivial", "soft_l1", "cauchy", "huber"]
 DepthLossName = Literal["trivial", "cauchy", "soft_l1"]
@@ -78,6 +79,7 @@ class BAOptions:
     triangulation: BATriangulationOptions = dc_field(default_factory=BATriangulationOptions)
     depth: BADepthOptions = dc_field(default_factory=BADepthOptions)
     intrinsics: BAIntrinsicsOptions = dc_field(default_factory=BAIntrinsicsOptions)
+    solver_backend: SolverBackendOptions = dc_field(default_factory=SolverBackendOptions)
 
     retriangulation_reproj_multiplier: float = 8.0
     first_iteration_error_multiplier: float = 2.0
@@ -105,5 +107,6 @@ class BAOptions:
                 "depth": BADepthOptions,
                 "intrinsics": BAIntrinsicsOptions,
                 "triangulation": BATriangulationOptions,
+                "solver_backend": SolverBackendOptions,
             },
         )

--- a/vidmap/mapper/options/solver.py
+++ b/vidmap/mapper/options/solver.py
@@ -1,0 +1,26 @@
+"""Ceres linear-solver backend selection shared by the large global solves."""
+
+from typing import Literal
+
+from pydantic import ConfigDict
+
+from vidmap.configuration.validators import dataclass as pydantic_dataclass
+
+LinearSolverName = Literal["sparse_schur", "iterative_schur"]
+PreconditionerName = Literal["jacobi", "schur_jacobi", "cluster_jacobi", "cluster_tridiagonal"]
+
+
+@pydantic_dataclass(frozen=True, config=ConfigDict(extra="forbid", strict=True))
+class SolverBackendOptions:
+    """Which Ceres linear solver runs one stage's Schur complement.
+
+    ``sparse_schur`` factorizes on a single thread, so ``iterative_schur`` is the
+    setting that keeps scaling with cores; ``use_cuda`` moves the linear algebra onto
+    the GPU and needs a CUDA-enabled Ceres. Both change the numerical path, so the
+    defaults reproduce the direct sparse solve. ``preconditioner`` is only consulted
+    by ``iterative_schur``.
+    """
+
+    linear_solver: LinearSolverName = "sparse_schur"
+    preconditioner: PreconditionerName = "schur_jacobi"
+    use_cuda: bool = False

--- a/vidmap/mapper/options/view_graph.py
+++ b/vidmap/mapper/options/view_graph.py
@@ -64,6 +64,8 @@ class RAOptions:
     max_rotation_error_deg: float = 0.0
     video_tracking_huber_scale: float = 0.1
     video_lc_cauchy_scale: float = 0.05
+    # One thread keeps the solve byte-identical; None means one, -1 means every core.
+    num_threads: Optional[int] = None
 
 
 @pydantic_dataclass(frozen=True, config=ConfigDict(extra="forbid", strict=True))

--- a/vidmap/mapper/stages/bundle_adjustment/adjuster.py
+++ b/vidmap/mapper/stages/bundle_adjustment/adjuster.py
@@ -32,6 +32,27 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
+class Point3DTable:
+    """Every point of one reconstruction snapshot, kept in reconstruction order.
+
+    Rows stay in reconstruction order because that order reaches Ceres through
+    ``variable_point3D_ids``; ``sorted_ids``/``order`` turn a per-image lookup into a
+    binary search instead of one pybind call per observation.
+    """
+
+    ids: np.ndarray
+    xyz: np.ndarray
+    track_lengths: np.ndarray
+    sorted_ids: np.ndarray
+    order: np.ndarray
+
+    def indices(self, point3D_ids) -> np.ndarray:
+        """Row of each requested id; observed ids always exist in the reconstruction."""
+        positions = np.searchsorted(self.sorted_ids, np.asarray(point3D_ids, dtype=np.int64))
+        return self.order[positions]
+
+
+@dataclass(frozen=True, kw_only=True)
 class BASolvePolicy:
     """Discrete scientific choices for one bundle-adjustment solve."""
 
@@ -336,35 +357,51 @@ class BundleAdjuster:
 
     @staticmethod
     def image_point3D_ids(image) -> np.ndarray:
-        return np.asarray([point.point3D_id for point in image.points2D], dtype=np.uint64)
-
-    def points3D_xyz(self, point3D_ids) -> np.ndarray:
-        return np.asarray(
-            [self.reconstruction.point3D(int(point3D_id)).xyz for point3D_id in point3D_ids],
-            dtype=np.float64,
-        ).reshape((-1, 3))
-
-    def small_triangulation_angle_mask(self, point3D_ids, min_angle: float) -> np.ndarray:
-        native_ids = set(int(value) for value in self.solve_state.native_problem.point3D_ids)
-        unique_point3D_ids = dict.fromkeys(int(value) for value in point3D_ids)
-        records = [
-            self.solve_state.native_problem.track(point3D_id)
-            for point3D_id in unique_point3D_ids
-            if point3D_id in native_ids
-        ]
-        result = native.filter_tracks_by_triangulation_angle(
-            self.solve_state.native_problem,
-            records,
-            min_angle,
+        points2D = image.points2D
+        return np.fromiter(
+            (point.point3D_id for point in points2D),
+            dtype=np.uint64,
+            count=len(points2D),
         )
-        small_ids = {int(track.point3D_id) for track in result.tracks if len(track.observations) == 0}
-        return np.asarray(
-            [int(point3D_id) in small_ids for point3D_id in point3D_ids],
-            dtype=bool,
+
+    def point3D_table(self) -> Point3DTable:
+        """Snapshot every point once so per-image work is numpy indexing, not pybind calls."""
+        points3D = self.reconstruction.points3D
+        ids = np.empty(len(points3D), dtype=np.int64)
+        xyz = np.empty((len(points3D), 3), dtype=np.float64)
+        track_lengths = np.empty(len(points3D), dtype=np.int64)
+        for index, (point3D_id, point) in enumerate(points3D.items()):
+            ids[index] = point3D_id
+            xyz[index] = point.xyz
+            track_lengths[index] = point.track.length()
+        order = np.argsort(ids)
+        return Point3DTable(
+            ids=ids,
+            xyz=xyz,
+            track_lengths=track_lengths,
+            sorted_ids=ids[order],
+            order=order,
         )
+
+    def small_triangulation_angle_ids(self, min_angle: float) -> np.ndarray:
+        """Sorted ids of the tracks the angle filter leaves without observations.
+
+        The filter is per-track independent, so one pass over the whole problem answers
+        every per-image query; the caller masks with ``small_triangulation_angle_mask``.
+        """
+        problem = self.solve_state.native_problem
+        records = [problem.track(point3D_id) for point3D_id in problem.point3D_ids]
+        result = native.filter_tracks_by_triangulation_angle(problem, records, min_angle)
+        small_ids = [int(track.point3D_id) for track in result.tracks if len(track.observations) == 0]
+        return np.sort(np.asarray(small_ids, dtype=np.int64))
+
+    @staticmethod
+    def small_triangulation_angle_mask(point3D_ids, small_ids: np.ndarray) -> np.ndarray:
+        return np.isin(np.asarray(point3D_ids, dtype=np.int64), small_ids)
 
     def estimate_truncation_multiplier(self) -> float:
         whitened_residuals = []
+        points = self.point3D_table()
         for image_id in self.reconstruction.reg_image_ids():
             image = self.reconstruction.images[image_id]
             point2D_indices = np.array(image.get_observation_point2D_idxs())
@@ -378,7 +415,11 @@ class BundleAdjuster:
             depth_priors = np.asarray(solve_image.depth_values)[valid_indices]
             stddevs = np.asarray(solve_image.depth_stddevs)[valid_indices]
             point3D_ids = self.image_point3D_ids(image)[valid_indices].astype(np.int64)
-            projected_depths = multiview_geometry.project_point_depths(self.reconstruction, image_id, point3D_ids)
+            projected_depths = multiview_geometry.project_world_points_with_colmap_camera(
+                image,
+                self.reconstruction.cameras[image.camera_id],
+                points.xyz[points.indices(point3D_ids)],
+            )[1]
             mask = (depth_priors > 0) & (projected_depths > 0)
             if mask.sum() == 0:
                 continue
@@ -421,16 +462,11 @@ class BundleAdjuster:
         self.solve_state.import_scene()
         depth_loss_type = native_loss_type(depth_options.reg_loss_name)
         optimized_image_ids = list(self.reconstruction.reg_image_ids())
-        track_lengths = {
-            point3D_id: self.reconstruction.points3D[point3D_id].track.length()
-            for point3D_id in self.reconstruction.points3D.keys()
-        }
+        points = self.point3D_table()
         camera_ids = [self.reconstruction.images[image_id].camera_id for image_id in optimized_image_ids]
-        variable_point3D_ids = [
-            int(point3D_id)
-            for point3D_id, track_length in track_lengths.items()
-            if track_length < self.options.variable_point_track_length_threshold
-        ]
+        variable_point3D_ids = points.ids[
+            points.track_lengths < self.options.variable_point_track_length_threshold
+        ].tolist()
         options = build_bundle_adjustment_options(
             image_order=optimized_image_ids,
             camera_ids=camera_ids,
@@ -443,6 +479,7 @@ class BundleAdjuster:
             reprojection_scale=self.options.reproj_loss_scale * keypoint_stddev,
             reprojection_weight=1 / keypoint_stddev**2,
             num_threads=self.options.num_threads,
+            solver_backend=self.options.solver_backend,
         )
 
         intrinsics_priors = []
@@ -463,6 +500,7 @@ class BundleAdjuster:
         depth_constraints = []
         depth_scales = []
         images_without_residuals = []
+        small_angle_ids = self.small_triangulation_angle_ids(depth_options.risky_triangulation_angle_deg)
         for image_id in optimized_image_ids:
             image = self.reconstruction.images[image_id]
             point2D_indices = np.array(image.get_observation_point2D_idxs())
@@ -475,15 +513,14 @@ class BundleAdjuster:
             point2D_indices = point2D_indices[valid]
             depths = depths[valid]
             point3D_ids = self.image_point3D_ids(image)[point2D_indices].astype(np.int64)
-            projected_depths = multiview_geometry.project_point_depths(self.reconstruction, image_id, point3D_ids)
-            risky_track_lengths = (
-                np.array([track_lengths[point3D_id] for point3D_id in point3D_ids])
-                < depth_options.risky_track_length_threshold
-            )
-            risky_angles = self.small_triangulation_angle_mask(
-                point3D_ids,
-                depth_options.risky_triangulation_angle_deg,
-            )
+            point_rows = points.indices(point3D_ids)
+            projected_depths = multiview_geometry.project_world_points_with_colmap_camera(
+                image,
+                self.reconstruction.cameras[image.camera_id],
+                points.xyz[point_rows],
+            )[1]
+            risky_track_lengths = points.track_lengths[point_rows] < depth_options.risky_track_length_threshold
+            risky_angles = self.small_triangulation_angle_mask(point3D_ids, small_angle_ids)
             risky_mask = risky_track_lengths | risky_angles
 
             mask = depths > 0
@@ -592,6 +629,7 @@ class BundleAdjuster:
 
     def estimate_depth_scales(self) -> dict:
         shift_scale = {}
+        points = self.point3D_table()
         for image_id in self.reconstruction.reg_image_ids():
             image = self.reconstruction.images[image_id]
             point2D_indices = np.array(image.get_observation_point2D_idxs())
@@ -608,7 +646,7 @@ class BundleAdjuster:
             if mask.sum() == 0:
                 logger.debug("No valid points for shift/scale estimation in image %d", image_id)
                 continue
-            points3D = self.points3D_xyz(point3D_ids)
+            points3D = points.xyz[points.indices(point3D_ids)]
             projected_depths = (image.cam_from_world() * points3D)[:, -1][mask]
             observed_depths = observed_depths[mask]
             proposed = np.median(np.log(projected_depths.clip(1e-6, None) / observed_depths.clip(1e-6, None)))
@@ -649,7 +687,7 @@ class BundleAdjuster:
         point3D_ids = np.array(list(self.reconstruction.points3D.keys()))
         risky_mask = self.small_triangulation_angle_mask(
             point3D_ids,
-            self.options.triangulation.min_angle,
+            self.small_triangulation_angle_ids(self.options.triangulation.min_angle),
         )
         count = 0
         for point3D_id in point3D_ids[risky_mask]:

--- a/vidmap/mapper/stages/bundle_adjustment/native_options.py
+++ b/vidmap/mapper/stages/bundle_adjustment/native_options.py
@@ -6,6 +6,8 @@ import numpy as np
 
 from vidmap.mapper.native.extension import native
 from vidmap.mapper.native.losses import build_named_loss_config, build_typed_loss_config
+from vidmap.mapper.native.solver_backend import apply_solver_backend
+from vidmap.mapper.options.solver import SolverBackendOptions
 
 
 def build_bundle_adjustment_options(
@@ -21,6 +23,7 @@ def build_bundle_adjustment_options(
     reprojection_scale: float,
     reprojection_weight: float,
     num_threads: int | None,
+    solver_backend: SolverBackendOptions,
 ):
     native_options = native.BundleAdjustmentOptions()
     native_options.image_order = list(image_order)
@@ -40,6 +43,7 @@ def build_bundle_adjustment_options(
     native_options.fix_all_poses = fix_all_poses
     native_options.use_log_depth_residual = True
     native_options.num_threads = -1 if num_threads is None else int(num_threads)
+    apply_solver_backend(native_options, solver_backend)
     return native_options
 
 

--- a/vidmap/mapper/stages/global_positioning/native_options.py
+++ b/vidmap/mapper/stages/global_positioning/native_options.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from vidmap.mapper.native.extension import native
 from vidmap.mapper.native.losses import build_named_loss_config, loss_config_from_options, native_loss_type
+from vidmap.mapper.native.solver_backend import apply_solver_backend
 from vidmap.mapper.options.positioning import GPOptions
 
 
@@ -52,6 +53,7 @@ def apply_global_positioning_policy(native_options, options: GPOptions):
     native_options.apply_uncalibrated_loss_downweight = common.apply_uncalibrated_loss_downweight
     if common.num_threads is not None:
         native_options.num_threads = common.num_threads
+    apply_solver_backend(native_options, options.solver_backend)
     native_options.min_num_views_per_track = options.track_filter.min_num_views_per_track
     native_options.random_init_scale = common.random_init_scale
     native_options.parameter_ordering = {

--- a/vidmap/mapper/stages/global_positioning/positioner.py
+++ b/vidmap/mapper/stages/global_positioning/positioner.py
@@ -317,6 +317,16 @@ class GlobalPositioner:
             for point3D_id in self.solve_state.native_problem.point3D_ids
         }
 
+    def export_solved_scene(self) -> None:
+        """Publish one solved pass to the pycolmap checkpoint.
+
+        Positioning moves point coordinates and poses but never track membership, so the
+        value-only track export is exact; it falls back to a full rebuild if ids diverge.
+        """
+        self.solve_state.export_cameras()
+        self.solve_state.export_poses()
+        self.solve_state.export_track_values()
+
     def first_pass(self, native_options, replay_images):
         input_summary = None
         if self.replay.write_enabled("gp1"):
@@ -333,7 +343,7 @@ class GlobalPositioner:
         if self.playback_trace is not None:
             self.playback_trace.attach_global_positioning(native_options, "gp1")
         result = native.run_global_positioning(native_options, self.solve_state.native_problem)
-        self.solve_state.export_scene()
+        self.export_solved_scene()
         replay_result = self.result_for_replay(result)
         if self.replay.write_enabled("gp1"):
             initial_state = capture_gp_initial_state("gp1", native_options, replay_result, input_summary, self.tracks)
@@ -372,14 +382,13 @@ class GlobalPositioner:
             stage="gp2",
             prior_specs=temporal_prior_specs,
         )
-        tracks = self.current_tracks()
         input_summary = None
         if self.replay.write_enabled("gp2"):
             input_summary = gp_input_summary(
                 "gp2",
                 self.solve_state,
                 replay_images,
-                tracks,
+                self.current_tracks(),
                 self.reconstruction.cameras,
             )
             self.replay.write_json("gp2", "input_rotations.json", gp_input_rotations(replay_images))
@@ -387,7 +396,7 @@ class GlobalPositioner:
         if self.playback_trace is not None:
             self.playback_trace.attach_global_positioning(native_options, "gp2")
         result = native.run_global_positioning(native_options, self.solve_state.native_problem)
-        self.solve_state.export_scene()
+        self.export_solved_scene()
         replay_result = self.result_for_replay(result)
         if self.replay.write_enabled("gp2"):
             self.replay.write_json(

--- a/vidmap/mapper/stages/rotation_averaging.py
+++ b/vidmap/mapper/stages/rotation_averaging.py
@@ -25,6 +25,7 @@ def _build_native_options(options: RAOptions):
     native_options.loop_closure_cauchy_scale = options.video_lc_cauchy_scale
     native_options.skip_risky_loop_closure_pairs = options.filter_risky_loop_closure_pairs
     native_options.filter_unregistered_images = options.filter_unregistered_images
+    native_options.num_threads = 1 if options.num_threads is None else int(options.num_threads)
     return native_options
 
 

--- a/vidmap/reconstruction.py
+++ b/vidmap/reconstruction.py
@@ -140,18 +140,46 @@ def write_local_input_provenance(directory: str | Path, image_dir: str | Path, *
     return path
 
 
-def propagate_local_input_provenance(
-    mapper_inputs: str | Path | MapperInputs, output_dir: str | Path, *, overwrite: bool
-) -> Path | None:
-    """Carry optional local-media provenance from a frontend into its mapping run."""
+def local_input_image_dir(mapper_inputs: str | Path | MapperInputs) -> Path | None:
+    """Return the RGB root recorded beside a mapper-inputs boundary, when present."""
     directory = (
         Path(mapper_inputs).expanduser() if isinstance(mapper_inputs, (str, Path)) else Path(mapper_inputs.directory)
     )
     source = directory.parent / LOCAL_INPUT_MANIFEST_NAME
-    if not source.is_file():
+    return _read_local_input_provenance(source) if source.is_file() else None
+
+
+def propagate_local_input_provenance(
+    mapper_inputs: str | Path | MapperInputs, output_dir: str | Path, *, overwrite: bool
+) -> Path | None:
+    """Carry optional local-media provenance from a frontend into its mapping run."""
+    image_dir = local_input_image_dir(mapper_inputs)
+    if image_dir is None:
         return None
-    image_dir = _read_local_input_provenance(source)
     return write_local_input_provenance(output_dir, image_dir, overwrite=overwrite)
+
+
+def extract_point_colors(reconstruction, mapper_inputs: str | Path | MapperInputs) -> bool:
+    """Sample point colors from the run's RGB images so COLMAP output is not uniformly black.
+
+    Colors are cosmetic, so a missing or unreadable image root degrades to a warning
+    rather than discarding a finished reconstruction.
+    """
+    try:
+        image_dir = local_input_image_dir(mapper_inputs)
+    except (FileNotFoundError, ValueError) as error:
+        logger.warning("Leaving points uncolored: %s", error)
+        return False
+    if image_dir is None:
+        logger.warning("Leaving points uncolored: no local input provenance beside %s", mapper_inputs)
+        return False
+    try:
+        reconstruction.extract_colors_for_all_images(str(image_dir))
+    except Exception:
+        logger.warning("Leaving points uncolored: color extraction failed for %s", image_dir, exc_info=True)
+        return False
+    logger.info("Extracted point colors from %s", image_dir)
+    return True
 
 
 def local_run_image_dir(run: str | Path) -> Path | None:

--- a/vidmap/run.py
+++ b/vidmap/run.py
@@ -71,6 +71,10 @@ def main(argv=None):
 
     from vidmap.mapper.runtime import load_mapping_runtime
 
+    # Keep this ahead of every torch import: libtorch_cpu.so exports its own statically
+    # linked BLAS/LAPACK (dgemm_, dpotrf_, ...), and if torch loads first those symbols win
+    # global resolution for SuiteSparse/Ceres, which makes CHOLMOD report "matrix not
+    # positive definite" and bundle adjustment fail.
     load_mapping_runtime()
 
     from vidmap.frontend.runner import run_local_frontend

--- a/vidmap/run.py
+++ b/vidmap/run.py
@@ -90,7 +90,7 @@ def main(argv=None):
     )
     logger.info("Mapper inputs ready: tag=%s path=%s", frontend.tag, frontend.path)
 
-    from vidmap.reconstruction import propagate_local_input_provenance, reconstruct
+    from vidmap.reconstruction import extract_point_colors, propagate_local_input_provenance, reconstruct
 
     output_dir = Path(args.output).expanduser()
     reconstruction = reconstruct(
@@ -105,6 +105,7 @@ def main(argv=None):
         overwrite_outputs=args.overwrite,
         output_dir=output_dir,
     )
+    extract_point_colors(reconstruction, frontend.mapper_inputs)
     reconstruction_dir = output_dir / "rec"
     reconstruction_dir.mkdir(parents=True, exist_ok=True)
     reconstruction.write(reconstruction_dir)


### PR DESCRIPTION
## Summary

Mapping spent most of its wall clock on one core. Sampling process-tree CPU once a
second across a 617-image run showed **740s of 1218s (61%) running on roughly a single
core**, almost none of it inside the native solvers. This branch removes the bulk of that
serial work, makes the Ceres solver backend configurable, fixes point colors, and repairs
the native build.

The same scene now finishes in **681s with 250s (37%) on one core**.

| | before | after |
|---|---|---|
| wall clock | 1218s | 681s |
| single-core time | 740s (61%) | 250s (37%) |
| mean cores (of 32) | 3.66 | 5.66 |
| global positioning, pass 1 | 123s @ 6.9 cores | 105s @ 7.7 cores |
| global positioning, pass 2 | 151s @ 6.8 cores | 126s @ 7.8 cores |
| BA problem construction, per round | 52–62s @ 1.0 core | 6–8s @ 1.0 core |
| mean reprojection error | 1.16164 | 1.16021 |
| registered images / points | 617 / 242576 | 617 / 242656 |

## What was slow

Every bundle-adjustment round spent 52–62s building the problem in Python before handing
a 35s solve to Ceres — preparation cost more than the solve itself, eight rounds in a row.

The dominant term was `small_triangulation_angle_mask`, called once per image inside the
per-image loop, each call materializing all 380k track ids into a Python list and then a
set. That work is loop-invariant, and the underlying filter is per-track independent, so
one pass over the problem answers every per-image query.

Two smaller serial costs sat alongside it: per-observation pybind lookups for point
coordinates and track lengths (~1.25M calls per round), and a full rebuild of every
pycolmap point after each positioning pass, which only moves coordinates.

## Changes

**Fix the native extension build against the installed COLMAP.** Rebuilding
`vidmap_native` currently yields a module that cannot be imported: COLMAP's static
libraries reference Abseil's logging internals without listing Abseil in their exported
configuration, leaving undefined `absl::log_internal` symbols, and a shared Ceres outside
the loader's search path is not found at import time. Links Abseil when available and
keeps link-time library directories in the installed RPATH.

**Extract point colors before writing a reconstruction.** Nothing on the mapping path
sampled color, so every `points3D.bin` carried RGB `(0, 0, 0)` and COLMAP rendered the
cloud black — only the HTML visualization called `extract_colors_for_all_images`, which
is why the same run looked colored there and blank in COLMAP. Color is cosmetic, so a
missing image root degrades to a warning rather than discarding a finished
reconstruction.

**Cut the single-threaded Python work between native solves.** Hoists the small-angle id
computation out of the per-image loop; snapshots point coordinates and track lengths into
one `Point3DTable` per solve so per-image lookups are a binary search. Rows stay in
reconstruction order because that order reaches Ceres through `variable_point3D_ids`.
Positioning passes now publish values instead of rebuilding all points, and the replay
track snapshot is only materialized when replay is enabled.

**Make the Ceres linear solver and thread counts configurable.** The global solves
hard-coded a direct sparse Schur factorization, whose factorization step is
single-threaded; rotation averaging was pinned to one thread with no way to change it.
Adds `linear_solver`, `preconditioner` and `use_cuda` for bundle adjustment and global
positioning, plus `num_threads` for rotation averaging.

```bash
python -m vidmap.map ... \
  mapper.ba.solver_backend.linear_solver=iterative_schur \
  mapper.gp.solver_backend.use_cuda=true \
  mapper.ra.num_threads=8
```

Every default reproduces current behavior: the direct sparse solve with CUDA off, and one
thread for rotation averaging, which keeps that stage byte-identical as its pinned random
seed intends. Requesting CUDA is rejected with a clear message when Ceres was built
without it. Also drops global positioning's `CLUSTER_TRIDIAGONAL` preconditioner, which
`SPARSE_SCHUR` ignores — timing it explicitly confirmed no difference.

## Verification

Multi-threaded Ceres is not bit-reproducible here, so results are compared against the
pipeline's own run-to-run spread after removing the similarity gauge:

- 89-image scene: baseline varies by **0.10%** of scene radius between two runs of
  unmodified code; before-versus-after differs by **0.05%**. Reprojection error 0.94155
  vs 0.94173, same 89 registered images.
- 617-image scene: self-noise **0.41%**, registered images and reprojection error
  unchanged.

## Notes for reviewers

- `iterative_schur` and `use_cuda` are wired but off by default and not yet recommended.
  On the 89-image scene `iterative_schur` was slower (3m43 vs 1m30) and converged to a
  materially different solution (scale off by 2x), so it needs tuning before it is
  useful.
- Two Ceres installs can be present, and CMake may prefer a shared build with
  EigenSparse only over the SuiteSparse build COLMAP was compiled against. That choice
  is worth **2x on global positioning** (212s @ 3.8 cores vs 105s @ 7.7 cores), so watch
  the `-- Found Ceres version:` configure line and pass `Ceres_DIR` if it picks the wrong
  one.
- This branch also carries the earlier `Expose full BA diagnostics and tidy descriptor
  loading` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
