### PR TITLE
Add public format check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,18 @@
+name: Format Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - run: pip install black==24.4.2 ruff==0.4.4 isort==5.13.2
+      - run: black --check --line-length=119 vidmap/
+      - run: ruff check --no-fix vidmap/
+      - run: isort --check-only --profile=black --line-length=119 vidmap/

--- a/vidmap/datasets/prepare/lamar.py
+++ b/vidmap/datasets/prepare/lamar.py
@@ -32,8 +32,7 @@ _GROUND_TRUTH_MODELS_FILENAME = "lamar_ground_truth_models.tar.gz"
 _GROUND_TRUTH_MODELS_SIZE = 11_689_090
 _GROUND_TRUTH_MODELS_SHA256 = "60770ead917d936fcef7b0115a8d67cd8044e7dc6655321e7e837923b3736428"
 _GROUND_TRUTH_MODELS_URL = (
-    "https://github.com/cvg/vidmap/releases/download/"
-    f"dataset-assets-v2/{_GROUND_TRUTH_MODELS_FILENAME}"
+    f"https://github.com/cvg/vidmap/releases/download/dataset-assets-v2/{_GROUND_TRUTH_MODELS_FILENAME}"
 )
 _PREPARATION_PROFILE = "sample-300"
 _SAMPLE_SHA256 = {


### PR DESCRIPTION
## Summary

- run Black, Ruff, and isort checks on pull requests targeting `main`
- format LaMAR asset URL so the baseline passes the pinned Black version

## Validation

- `black --check --line-length=119 vidmap/`
- `ruff check --no-fix vidmap/`
- `isort --check-only --profile=black --line-length=119 vidmap/`
- `git diff --check`
