### PR TITLE
Stabilize global positioning with sequential warm-up

### DIFF
--- a/extensions/colmap/src/bindings/global_positioning.cc
+++ b/extensions/colmap/src/bindings/global_positioning.cc
@@ -79,6 +79,16 @@ void BindGlobalPositioning(py::module_& m) {
                      &GlobalPositionerOptions::optimize_points)
       .def_readwrite("optimize_scales",
                      &GlobalPositionerOptions::optimize_scales)
+      .def_readwrite("sequential_support_warmup_rounds",
+                     &GlobalPositionerOptions::sequential_support_warmup_rounds)
+      .def_readwrite(
+          "sequential_support_observations_per_track",
+          &GlobalPositionerOptions::sequential_support_observations_per_track)
+      .def_readwrite("sequential_support_loss",
+                     &GlobalPositionerOptions::sequential_support_loss)
+      .def_readwrite(
+          "sequential_support_image_timeline",
+          &GlobalPositionerOptions::sequential_support_image_timeline)
       .def_readwrite("min_num_views_per_track",
                      &GlobalPositionerOptions::min_num_view_per_track)
       .def_readwrite("random_seed", &GlobalPositionerOptions::random_seed)
@@ -153,8 +163,7 @@ void BindGlobalPositioning(py::module_& m) {
                      &GlobalPositionerOptions::gradient_tolerance)
       .def_readwrite("parameter_tolerance",
                      &GlobalPositionerOptions::parameter_tolerance)
-      .def_readwrite("solver_backend",
-                     &GlobalPositionerOptions::solver_backend)
+      .def_readwrite("solver_backend", &GlobalPositionerOptions::solver_backend)
       .def_readwrite("playback", &GlobalPositionerOptions::playback)
       .def("validate", &GlobalPositionerOptions::Validate);
 

--- a/extensions/colmap/src/bindings/module.cc
+++ b/extensions/colmap/src/bindings/module.cc
@@ -1,19 +1,12 @@
 #include "bindings.h"
 #include <pybind11/pybind11.h>
 
-namespace {
-
-constexpr int kApiVersion = 5;
-
-}  // namespace
-
 #ifndef VIDMAP_COLMAP_REVISION
 #error "VIDMAP_COLMAP_REVISION must be defined by CMake"
 #endif
 
 PYBIND11_MODULE(_core, m) {
   m.doc() = "VidMap native mapping algorithms";
-  m.attr("__api_version__") = kApiVersion;
   m.attr("__colmap_revision__") = VIDMAP_COLMAP_REVISION;
   vidmap::BindRecords(m);
   vidmap::BindSolverPlayback(m);

--- a/extensions/colmap/src/stages/global_positioning.cc
+++ b/extensions/colmap/src/stages/global_positioning.cc
@@ -83,6 +83,28 @@ class DeadZoneHuberLoss final : public ceres::LossFunction {
   const double huber_width_;
 };
 
+class WarmupLoss final : public ceres::LossFunction {
+ public:
+  WarmupLoss(const ceres::LossFunction* normal,
+             const ceres::LossFunction* warmup)
+      : normal_(normal), warmup_(warmup) {
+    if (normal_ == nullptr || warmup_ == nullptr) {
+      throw std::invalid_argument("warm-up loss requires two losses");
+    }
+  }
+
+  void SetWarmup(const bool enabled) { use_warmup_ = enabled; }
+
+  void Evaluate(const double squared_norm, double rho[3]) const override {
+    (use_warmup_ ? warmup_ : normal_)->Evaluate(squared_norm, rho);
+  }
+
+ private:
+  const ceres::LossFunction* normal_;
+  const ceres::LossFunction* warmup_;
+  bool use_warmup_ = false;
+};
+
 Eigen::Quaterniond ImageRotation(const ImageRecord& image) {
   return ToColmapPose(image.pose).rotation();
 }
@@ -116,9 +138,14 @@ class GlobalPositioner {
       AddCamerasAndPointsToParameterGroups();
     }
     ParameterizeVariables();
+    const int support_rounds = options_.sequential_support_warmup_rounds;
 
     ceres::Solver::Summary summary;
     try {
+      if (support_rounds > 0 && options_.playback.IsEnabled()) {
+        WritePlaybackCapture("initial", -1);
+      }
+      RunSequentialSupportWarmup();
       SolveWithPlayback(
           options_.playback,
           solver_options_,
@@ -126,7 +153,8 @@ class GlobalPositioner {
           [this](const char* phase, const int iteration) {
             WritePlaybackCapture(phase, iteration);
           },
-          &summary);
+          &summary,
+          support_rounds);
     } catch (...) {
       ConvertBackResults();
       throw;
@@ -169,6 +197,24 @@ class GlobalPositioner {
             "global positioning requires one image per frame");
       }
     }
+    chronological_image_indices_.clear();
+    if (options_.sequential_support_warmup_rounds > 0) {
+      for (std::size_t index = 0;
+           index < options_.sequential_support_image_timeline.size();
+           ++index) {
+        const ImageId image_id =
+            options_.sequential_support_image_timeline[index];
+        if (image_ids_.count(image_id) == 0 ||
+            !chronological_image_indices_.emplace(image_id, index).second) {
+          throw std::invalid_argument(
+              "sequential support requires an exact unique image timeline");
+        }
+      }
+      if (chronological_image_indices_.size() != image_ids_.size()) {
+        throw std::invalid_argument(
+            "sequential support requires an exact unique image timeline");
+      }
+    }
   }
 
   void SetupProblem() {
@@ -196,6 +242,7 @@ class GlobalPositioner {
     depth_outliers_.clear();
     per_image_scale_prior_losses_.clear();
     temporal_acceleration_losses_.clear();
+    has_sequential_support_candidate_ = false;
     result_ = GlobalPositioningResult();
 
     loss_ = SharedLoss(options_.loss);
@@ -223,6 +270,33 @@ class GlobalPositioner {
     loss_normal_depth_track_anchor_ =
         SharedLoss(options_.loss_normal_depth_track_anchor);
     loss_scale_prior_ = SharedLoss(options_.loss_scale_prior);
+    if (options_.sequential_support_warmup_rounds > 0) {
+      sequential_support_calibrated_loss_ =
+          SharedLoss(options_.sequential_support_loss);
+      sequential_support_uncalibrated_loss_ =
+          options_.apply_uncalibrated_loss_downweight
+              ? std::make_shared<ceres::ScaledLoss>(
+                    sequential_support_calibrated_loss_.get(),
+                    options_.uncalibrated_loss_downweight,
+                    ceres::DO_NOT_TAKE_OWNERSHIP)
+              : sequential_support_calibrated_loss_;
+      ceres::LossFunction* normal_calibrated_loss =
+          options_.use_metric_depth_constraint ? loss_normal_geometry_.get()
+                                               : calibrated_loss_.get();
+      ceres::LossFunction* normal_uncalibrated_loss =
+          options_.use_metric_depth_constraint ? loss_normal_geometry_.get()
+                                               : uncalibrated_loss_.get();
+      sequential_support_calibrated_switch_ = std::make_unique<WarmupLoss>(
+          normal_calibrated_loss, sequential_support_calibrated_loss_.get());
+      sequential_support_uncalibrated_switch_ = std::make_unique<WarmupLoss>(
+          normal_uncalibrated_loss,
+          sequential_support_uncalibrated_loss_.get());
+    } else {
+      sequential_support_calibrated_loss_.reset();
+      sequential_support_uncalibrated_loss_.reset();
+      sequential_support_calibrated_switch_.reset();
+      sequential_support_uncalibrated_switch_.reset();
+    }
     loss_soft_outlier_fallback_.reset();
 
     solver_options_.num_threads = options_.num_threads;
@@ -403,6 +477,34 @@ class GlobalPositioner {
     }
   }
 
+  std::set<std::pair<ImageId, std::uint32_t>> SelectTrackSupport(
+      const TrackRecord& track) const {
+    std::vector<Observation> observations;
+    observations.reserve(track.observations.rows());
+    for (Eigen::Index row = 0; row < track.observations.rows(); ++row) {
+      observations.push_back(
+          {track.observations(row, 0), track.observations(row, 1)});
+    }
+    std::sort(observations.begin(),
+              observations.end(),
+              [this](const Observation& lhs, const Observation& rhs) {
+                return std::tie(chronological_image_indices_.at(lhs.image_id),
+                                lhs.point2D_idx) <
+                       std::tie(chronological_image_indices_.at(rhs.image_id),
+                                rhs.point2D_idx);
+              });
+
+    std::set<std::pair<ImageId, std::uint32_t>> selected;
+    const std::size_t count = std::min<std::size_t>(
+        options_.sequential_support_observations_per_track,
+        observations.size());
+    for (std::size_t index = 0; index < count; ++index) {
+      selected.emplace(observations[index].image_id,
+                       observations[index].point2D_idx);
+    }
+    return selected;
+  }
+
   void AddPoint3DToProblem(Point3DId point3D_id) {
     const bool random_initialization = options_.optimize_points &&
                                        options_.generate_random_points &&
@@ -414,12 +516,21 @@ class GlobalPositioner {
     result_.initial_point3D_xyz.emplace(point3D_id, xyz);
 
     const TrackRecord& track = mapping_problem_->Track(point3D_id);
+    const bool support_enabled = options_.sequential_support_warmup_rounds > 0;
+    const std::set<std::pair<ImageId, std::uint32_t>> track_support =
+        support_enabled ? SelectTrackSupport(track)
+                        : std::set<std::pair<ImageId, std::uint32_t>>{};
     for (Eigen::Index row = 0; row < track.observations.rows(); ++row) {
+      const Observation observation{track.observations(row, 0),
+                                    track.observations(row, 1)};
       AddObservation(point3D_id,
-                     {track.observations(row, 0), track.observations(row, 1)},
+                     observation,
                      random_initialization,
                      false,
-                     std::nullopt);
+                     std::nullopt,
+                     support_enabled &&
+                         track_support.count({observation.image_id,
+                                              observation.point2D_idx}) != 0);
     }
     if (options_.use_lc_observations) {
       for (Eigen::Index row = 0; row < track.loop_closure_observations.rows();
@@ -434,7 +545,8 @@ class GlobalPositioner {
                         track.loop_closure_observations(row, 1)},
                        random_initialization,
                        true,
-                       anchor);
+                       anchor,
+                       false);
       }
     }
   }
@@ -443,7 +555,8 @@ class GlobalPositioner {
                       const Observation& observation,
                       bool random_initialization,
                       bool is_loop_closure,
-                      const std::optional<Observation>& loop_closure_anchor) {
+                      const std::optional<Observation>& loop_closure_anchor,
+                      bool selected_by_track_support) {
     if (image_ids_.count(observation.image_id) == 0) return;
     const ImageRecord& image = mapping_problem_->Image(observation.image_id);
     if (!image.pose.has_pose) return;
@@ -489,6 +602,20 @@ class GlobalPositioner {
       geometry_loss = is_track_anchor ? loss_normal_geometry_track_anchor_.get()
                       : is_inlier     ? loss_normal_geometry_inlier_.get()
                                       : loss_normal_geometry_.get();
+    }
+    if (selected_by_track_support) {
+      const double world_bearing_norm = point_from_camera_direction.norm();
+      if (!std::isfinite(world_bearing_norm) || world_bearing_norm <= 1e-12) {
+        selected_by_track_support = false;
+      }
+    }
+    if (selected_by_track_support) {
+      has_sequential_support_candidate_ = true;
+      if (!is_track_anchor && !is_inlier) {
+        geometry_loss = camera.has_prior_focal_length
+                            ? sequential_support_calibrated_switch_.get()
+                            : sequential_support_uncalibrated_switch_.get();
+      }
     }
 
     ceres::CostFunction* cost = nullptr;
@@ -901,6 +1028,37 @@ class GlobalPositioner {
         colmap::GetEffectiveNumThreads(solver_options_.num_threads);
   }
 
+  void RunSequentialSupportWarmup() {
+    const int rounds = options_.sequential_support_warmup_rounds;
+    if (rounds == 0) return;
+    if (!has_sequential_support_candidate_) {
+      throw std::runtime_error(
+          "sequential support has no eligible regular observations");
+    }
+
+    ceres::Solver::Options warmup_options = solver_options_;
+    warmup_options.max_num_iterations = 1;
+    SetSequentialSupportWarmup(true);
+    for (int round = 0; round < rounds; ++round) {
+      ceres::Solver::Summary summary;
+      ceres::Solve(warmup_options, problem_.get(), &summary);
+      if (!summary.IsSolutionUsable()) {
+        SetSequentialSupportWarmup(false);
+        throw std::runtime_error("sequential support warm-up failed");
+      }
+      if (options_.playback.IsEnabled() &&
+          round % options_.playback.snapshot_every_n_iterations == 0) {
+        WritePlaybackCapture("iteration", round);
+      }
+    }
+    SetSequentialSupportWarmup(false);
+  }
+
+  void SetSequentialSupportWarmup(const bool enabled) {
+    sequential_support_calibrated_switch_->SetWarmup(enabled);
+    sequential_support_uncalibrated_switch_->SetWarmup(enabled);
+  }
+
   void FindDepthOutliers() {
     for (const Point3DId point3D_id : mapping_problem_->Point3DIds()) {
       const TrackRecord& track = mapping_problem_->Track(point3D_id);
@@ -997,6 +1155,7 @@ class GlobalPositioner {
   const GlobalPositionerOptions& options_;
   MappingProblem* mapping_problem_;
   std::unordered_set<ImageId> image_ids_;
+  std::unordered_map<ImageId, std::size_t> chronological_image_indices_;
   std::unique_ptr<ceres::Problem> problem_;
   ceres::Solver::Options solver_options_;
   std::map<Point3DId, Eigen::Vector3d> point_xyz_;
@@ -1026,11 +1185,16 @@ class GlobalPositioner {
   std::shared_ptr<ceres::LossFunction> loss_normal_geometry_track_anchor_;
   std::shared_ptr<ceres::LossFunction> loss_normal_depth_track_anchor_;
   std::shared_ptr<ceres::LossFunction> loss_scale_prior_;
+  std::shared_ptr<ceres::LossFunction> sequential_support_calibrated_loss_;
+  std::shared_ptr<ceres::LossFunction> sequential_support_uncalibrated_loss_;
+  std::unique_ptr<WarmupLoss> sequential_support_calibrated_switch_;
+  std::unique_ptr<WarmupLoss> sequential_support_uncalibrated_switch_;
   std::shared_ptr<ceres::LossFunction> loss_soft_outlier_fallback_;
   std::vector<std::unique_ptr<ceres::LossFunction>>
       per_image_scale_prior_losses_;
   std::vector<std::unique_ptr<ceres::LossFunction>>
       temporal_acceleration_losses_;
+  bool has_sequential_support_candidate_ = false;
   GlobalPositioningResult result_;
 };
 
@@ -1045,6 +1209,8 @@ void GlobalPositionerOptions::Validate() const {
   }
   if (min_num_view_per_track <= 0 || random_seed < -1 ||
       !std::isfinite(random_init_scale) || random_init_scale < 0.0 ||
+      sequential_support_warmup_rounds < 0 ||
+      sequential_support_observations_per_track < 0 ||
       !std::isfinite(uncalibrated_loss_downweight) ||
       uncalibrated_loss_downweight < 0.0 ||
       !std::isfinite(log_linear_threshold) || log_linear_threshold <= 0.0 ||
@@ -1065,6 +1231,15 @@ void GlobalPositionerOptions::Validate() const {
       parameter_tolerance < 0.0) {
     throw std::invalid_argument("invalid global positioning options");
   }
+  const bool sequential_support_enabled = sequential_support_warmup_rounds > 0;
+  if (sequential_support_enabled !=
+          (sequential_support_observations_per_track > 0) ||
+      sequential_support_enabled !=
+          !sequential_support_image_timeline.empty()) {
+    throw std::invalid_argument(
+        "sequential support requires positive rounds, observations per track, "
+        "and an image timeline");
+  }
   if (use_temporal_acceleration_prior &&
       (temporal_acceleration_priors.empty() ||
        temporal_acceleration_prior_weight <= 0.0)) {
@@ -1083,6 +1258,7 @@ void GlobalPositionerOptions::Validate() const {
     }
   }
   loss.Validate();
+  sequential_support_loss.Validate();
   loss_soft_outlier_fallback.Validate();
   loss_normal_geometry.Validate();
   loss_normal_depth.Validate();

--- a/extensions/colmap/src/stages/solver_playback.h
+++ b/extensions/colmap/src/stages/solver_playback.h
@@ -13,19 +13,24 @@ namespace vidmap {
 class SolverPlaybackIterationCallback final : public ceres::IterationCallback {
  public:
   SolverPlaybackIterationCallback(const int interval,
+                                  const int iteration_offset,
                                   std::function<void(int)> capture)
-      : interval_(interval), capture_(std::move(capture)) {}
+      : interval_(interval),
+        iteration_offset_(iteration_offset),
+        capture_(std::move(capture)) {}
 
   ceres::CallbackReturnType operator()(
       const ceres::IterationSummary& summary) override {
-    if (summary.iteration % interval_ == 0) {
-      capture_(summary.iteration);
+    const int iteration = summary.iteration + iteration_offset_;
+    if (iteration % interval_ == 0) {
+      capture_(iteration);
     }
     return ceres::SOLVER_CONTINUE;
   }
 
  private:
   int interval_;
+  int iteration_offset_;
   std::function<void(int)> capture_;
 };
 
@@ -55,22 +60,28 @@ void SolveWithPlayback(const SolverPlaybackOptions& playback,
                        ceres::Solver::Options solver_options,
                        ceres::Problem* problem,
                        Capture&& capture,
-                       ceres::Solver::Summary* summary) {
+                       ceres::Solver::Summary* summary,
+                       const int iteration_offset = 0) {
   if (!playback.IsEnabled()) {
     ceres::Solve(solver_options, problem, summary);
     return;
   }
 
-  capture("initial", -1);
+  if (iteration_offset == 0) {
+    capture("initial", -1);
+  }
   SolverPlaybackIterationCallback callback(
       playback.snapshot_every_n_iterations,
+      iteration_offset,
       [&capture](const int iteration) { capture("iteration", iteration); });
   solver_options.update_state_every_iteration = true;
   solver_options.callbacks.push_back(&callback);
   ceres::Solve(solver_options, problem, summary);
   if (summary->IsSolutionUsable()) {
     const int iteration =
-        summary->iterations.empty() ? -1 : summary->iterations.back().iteration;
+        summary->iterations.empty()
+            ? iteration_offset - 1
+            : summary->iterations.back().iteration + iteration_offset;
     capture("final", iteration);
   }
 }

--- a/extensions/colmap/src/vidmap_native/global_positioning.h
+++ b/extensions/colmap/src/vidmap_native/global_positioning.h
@@ -45,6 +45,11 @@ struct GlobalPositionerOptions {
   bool optimize_positions = true;
   bool optimize_points = true;
   bool optimize_scales = true;
+  // Temporarily apply a separate loss to early observations of each track.
+  int sequential_support_warmup_rounds = 0;
+  int sequential_support_observations_per_track = 0;
+  LossConfig sequential_support_loss;
+  std::vector<ImageId> sequential_support_image_timeline;
   int min_num_view_per_track = 3;
   int random_seed = -1;
   double random_init_scale = 100.0;

--- a/extensions/colmap/tests/python/test_global_positioning.py
+++ b/extensions/colmap/tests/python/test_global_positioning.py
@@ -54,6 +54,128 @@ def _playback_problem():
     return problem
 
 
+def _sequential_support_problem(storage_order):
+    problem = _playback_problem()
+    track = problem.track(7)
+    track.observations = np.asarray([[image_id, 0] for image_id in storage_order], dtype=np.uint32)
+    track.loop_closure_observations = np.empty((0, 2), dtype=np.uint32)
+    track.loop_closure_anchors = np.empty((0, 2), dtype=np.uint32)
+    problem.update_track(track)
+    return problem
+
+
+def test_sequential_support_warms_up_with_early_track_observations():
+    problem = _sequential_support_problem([3, 1, 2])
+    options = native.GlobalPositioningOptions()
+    options.generate_random_positions = False
+    options.generate_random_points = False
+    options.use_initial_positions = True
+    options.min_num_views_per_track = 2
+    options.num_threads = 1
+    options.max_num_iterations = 1
+    options.sequential_support_warmup_rounds = 2
+    options.sequential_support_observations_per_track = 2
+    options.sequential_support_loss.type = native.LossFunctionType.TRIVIAL
+    options.sequential_support_image_timeline = [1, 2, 3]
+
+    result = native.run_global_positioning(options, problem)
+
+    assert result.success
+    np.testing.assert_allclose(
+        problem.track(7).xyz,
+        [0.14776050274252941, 0.004862738467740601, 3.4976693525562697],
+        rtol=0.0,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        [result.final_bata_scales[key] for key in ("7:1:0:0", "7:2:0:0", "7:3:0:0")],
+        [0.5868746726257932, 0.5785674026758529, 1.0],
+        rtol=0.0,
+        atol=1e-12,
+    )
+
+
+def test_sequential_support_requires_complete_unique_timeline():
+    options = native.GlobalPositioningOptions()
+    options.sequential_support_warmup_rounds = 2
+    options.sequential_support_observations_per_track = 2
+    options.sequential_support_image_timeline = [1, 2]
+
+    with np.testing.assert_raises(ValueError):
+        native.run_global_positioning(options, _sequential_support_problem([1, 2, 3]))
+
+
+def test_sequential_support_uses_explicit_chronology():
+    def solve(timeline):
+        problem = _sequential_support_problem([3, 1, 2])
+        for image_id in (1, 2):
+            image = problem.image(image_id)
+            image.is_inlier = np.ones(1, dtype=np.uint8)
+            problem.update_image(image)
+        options = native.GlobalPositioningOptions()
+        options.generate_random_positions = False
+        options.generate_random_points = False
+        options.use_initial_positions = True
+        options.min_num_views_per_track = 2
+        options.num_threads = 1
+        options.max_num_iterations = 1
+        options.sequential_support_warmup_rounds = 2
+        options.sequential_support_observations_per_track = 2
+        options.sequential_support_image_timeline = timeline
+        native.run_global_positioning(options, problem)
+        return problem.track(7).xyz
+
+    np.testing.assert_allclose(
+        solve([1, 2, 3]),
+        [0.09679540707997863, 0.13290493297426395, 3.353711273003999],
+        rtol=0.0,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        solve([3, 2, 1]),
+        [0.011432501623407216, 0.3830162700655329, 2.9690467648852747],
+        rtol=0.0,
+        atol=1e-12,
+    )
+
+
+def test_sequential_support_is_disabled_by_default():
+    result = native.run_global_positioning(
+        native.GlobalPositioningOptions(),
+        _sequential_support_problem([1, 2, 3]),
+    )
+
+    assert result.success
+
+
+def test_sequential_support_playback_starts_before_warmup():
+    captures = []
+    options = native.GlobalPositioningOptions()
+    options.generate_random_positions = False
+    options.generate_random_points = False
+    options.use_initial_positions = True
+    options.min_num_views_per_track = 2
+    options.num_threads = 1
+    options.max_num_iterations = 1
+    options.sequential_support_warmup_rounds = 4
+    options.sequential_support_observations_per_track = 2
+    options.sequential_support_loss.type = native.LossFunctionType.TRIVIAL
+    options.sequential_support_image_timeline = [1, 2, 3]
+    options.playback.snapshot_every_n_iterations = 3
+    options.playback.callback = captures.append
+
+    result = native.run_global_positioning(options, _sequential_support_problem([3, 1, 2]))
+
+    assert captures[0]["phase"] == "initial"
+    assert captures[0]["iteration"] == -1
+    np.testing.assert_array_equal(captures[0]["points_xyz"][0], result.initial_point3D_xyz[7])
+    assert [(capture["phase"], capture["iteration"]) for capture in captures[1:-1]] == [
+        ("iteration", 0),
+        ("iteration", 3),
+    ]
+    assert captures[-1]["phase"] == "final"
+
+
 def test_global_positioning_playback_emits_owned_loop_closure_state():
     problem = _playback_problem()
     captures = []

--- a/extensions/colmap/tests/python/test_records.py
+++ b/extensions/colmap/tests/python/test_records.py
@@ -3,10 +3,6 @@ import pytest
 import vidmap_native._core as native
 
 
-def test_native_api_version_is_explicit():
-    assert native.__api_version__ == 5
-
-
 def test_global_positioning_ordering_names_are_current():
     assert set(native.GlobalPositioningOrdering.__members__) == {"GROUPED", "SINGLETON"}
 

--- a/vidmap/configs/mapping/uncalib/smooth_trajectory.yaml
+++ b/vidmap/configs/mapping/uncalib/smooth_trajectory.yaml
@@ -6,8 +6,8 @@ mapper:
     temporal_acceleration:
       coordinate: keyframe_index
       stddev: 3.0
-      first_pass_weight: 10.0
-      second_pass_weight: 10.0
+      first_pass_weight: 30.0
+      second_pass_weight: 30.0
       first_pass_dead_zone: 0.0
       first_pass_huber_width: 1000000000.0
       second_pass_dead_zone: 0.0

--- a/vidmap/mapper/options/positioning.py
+++ b/vidmap/mapper/options/positioning.py
@@ -59,6 +59,9 @@ class GPFirstPassOptions:
     scale_reg_loss_name: ScaleLossName = "trivial"
     scale_reg_weight: float = 1.0
     initialize_warm_start_scales: bool = True
+    sequential_support_warmup_rounds: Annotated[int, Field(ge=0)] = 16
+    sequential_support_observations_per_track: Annotated[int, Field(ge=0)] = 16
+    sequential_support_loss: Optional[LossConfig] = LossConfig(name="trivial", weight=1.0)
     loss_lc_geometry: LossConfig = LossConfig(name="cauchy", scale=2.0, weight=0.4)
     loss_lc_depth: LossConfig = LossConfig(name="cauchy", scale=2.0, weight=0.4)
     loss_normal_geometry: LossConfig = LossConfig(name="huber")
@@ -74,8 +77,18 @@ class GPFirstPassOptions:
                 "loss_lc_depth",
                 "loss_normal_geometry",
                 "loss_normal_depth",
+                "sequential_support_loss",
             ),
         )
+
+    @model_validator(mode="after")
+    def validate_sequential_support(self):
+        enabled = self.sequential_support_warmup_rounds > 0
+        if enabled != (self.sequential_support_observations_per_track > 0) or enabled != (
+            self.sequential_support_loss is not None
+        ):
+            raise ValueError("sequential support requires warm-up rounds, observations per track, and a loss")
+        return self
 
 
 @pydantic_dataclass(frozen=True, kw_only=True, config=ConfigDict(extra="forbid", strict=True))

--- a/vidmap/mapper/stages/global_positioning/native_options.py
+++ b/vidmap/mapper/stages/global_positioning/native_options.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -67,12 +67,24 @@ def apply_global_positioning_policy(native_options, options: GPOptions):
     return native_options
 
 
-def build_first_global_positioning_options(options: GPOptions, *, depth_outliers_marked: bool):
+def build_first_global_positioning_options(
+    options: GPOptions,
+    *,
+    depth_outliers_marked: bool,
+    image_timeline: Sequence[int],
+):
     native_options = native.GlobalPositioningOptions()
     common = options.common
     first = options.first_pass
     native_options.use_metric_depth_constraint = common.use_metric_depth_constraint
     native_options.optimize_scales = common.optimize_depth_map_scales
+    if first.sequential_support_warmup_rounds > 0:
+        if not image_timeline:
+            raise ValueError("sequential support requires an image timeline")
+        native_options.sequential_support_warmup_rounds = first.sequential_support_warmup_rounds
+        native_options.sequential_support_observations_per_track = first.sequential_support_observations_per_track
+        native_options.sequential_support_loss = loss_config_from_options(first.sequential_support_loss)
+        native_options.sequential_support_image_timeline = [int(image_id) for image_id in image_timeline]
     native_options.loss_loop_closure_geometry = loss_config_from_options(first.loss_lc_geometry)
     native_options.loss_loop_closure_depth = loss_config_from_options(first.loss_lc_depth)
     native_options.loss_normal_geometry = loss_config_from_options(first.loss_normal_geometry)
@@ -128,6 +140,10 @@ def configure_second_global_positioning_options(
     native_options.loss_normal_depth = loss_config_from_options(second.loss_normal_depth)
     native_options.use_initial_positions = True
     native_options.generate_scales = False
+    if options.first_pass.sequential_support_warmup_rounds > 0:
+        native_options.sequential_support_warmup_rounds = 0
+        native_options.sequential_support_observations_per_track = 0
+        native_options.sequential_support_image_timeline = []
     native_options.filter_depth_outliers = False
     native_options.initial_depth_map_scales = first_result.depth_map_scales
     native_options.initial_frame_centers = dict(initial_frame_centers)

--- a/vidmap/mapper/stages/global_positioning/positioner.py
+++ b/vidmap/mapper/stages/global_positioning/positioner.py
@@ -537,6 +537,13 @@ class GlobalPositioner:
         native_options, self.first_pass_tolerances = build_first_global_positioning_options(
             self.options,
             depth_outliers_marked=self.boundary_depth_outliers_marked or max_depth is not None,
+            image_timeline=[
+                int(image_id)
+                for image_id, _index in sorted(
+                    self.sequence_id_to_index.items(),
+                    key=lambda item: item[1],
+                )
+            ],
         )
         configure_temporal_acceleration_options(
             native_options,


### PR DESCRIPTION
## Summary

Global positioning is non-convex. In forward-motion sequences, optimization can open a gap between neighboring parts of the trajectory. Huber robustification can then weaken the sequential constraints needed to close it.

At the start of global positioning, this change temporarily uses a squared loss on early track observations, then restores the normal loss. The warm-up is enabled by default. Optional trajectory smoothing increases from weight 10 to 30 and remains opt-in.

## Results

The change has little effect on the main benchmark results, while improving robustness in long forward-motion corner cases observed in external videos.
